### PR TITLE
Add WSL2 Keep-Alive GUI Concept Script

### DIFF
--- a/README-keepalive.md
+++ b/README-keepalive.md
@@ -1,0 +1,19 @@
+# WSL2 Keep-Alive GUI Concept
+
+This Python script provides a simple graphical interface to keep WSL2 alive by periodically checking the status of Nginx.  
+It acts as a "keep-alive" tool to prevent WSL2 from shutting down automatically due to inactivity.
+
+## How it works
+
+- Every X seconds (configurable at the top of the script), the program runs a command in WSL2 to check if Nginx is running.
+- As long as the script is open, WSL2 remains active.
+- A timer shows the time since the last WSL request.
+
+## Usage
+
+1. Install Python on Windows.
+2. Run:
+   ```sh
+   python wsl_nginx_gui.py
+   ```
+3. Adjust the check interval by changing the `CHECK_INTERVAL_MS` variable at the top of the script.

--- a/wsl_nginx_gui.py
+++ b/wsl_nginx_gui.py
@@ -1,0 +1,50 @@
+import tkinter as tk
+import subprocess
+import time
+
+# Around 15000 ms it will timeout and the browser wont open blog.test anymore
+CHECK_INTERVAL_MS = 12000
+last_wsl_request = None
+main_window = None
+label_result = None
+label_clock = None
+
+def check_nginx():
+    global last_wsl_request
+    try:
+        result = subprocess.run(
+            ["wsl", "bash", "-c", "systemctl is-active nginx"],
+            capture_output=True, text=True, timeout=5
+        )
+        status = result.stdout.strip()
+        if status == "active":
+            last_wsl_request = time.time()
+            label_result.config(text="Nginx is running ✅", fg="green")
+        else:
+            label_result.config(text="Nginx is NOT running ❌", fg="red")
+    except Exception as e:
+        label_result.config(text=f"Error: {e}", fg="orange")
+    # Agenda próxima checagem usando a variável global
+    main_window.after(CHECK_INTERVAL_MS, check_nginx)
+
+def update_uptime_clock():
+    if last_wsl_request:
+        elapsed = int(time.time() - last_wsl_request)
+        label_clock.config(text=f"Last WSL request: {elapsed} seconds ago")
+    else:
+        label_clock.config(text="Waiting for first WSL request...")
+    main_window.after(1000, update_uptime_clock)
+
+main_window = tk.Tk()
+main_window.title("WSL2 Nginx Status Checker")
+
+label_result = tk.Label(main_window, text="Checking Nginx status...", font=("Arial", 12))
+label_result.pack(padx=20, pady=10)
+
+label_clock = tk.Label(main_window, text="", font=("Arial", 10), fg="blue")
+label_clock.pack(padx=20, pady=10)
+
+check_nginx()
+update_uptime_clock()
+
+main_window.mainloop()


### PR DESCRIPTION
This PR introduces a simple Python GUI script (wsl_nginx_gui.py) that acts as a keep-alive for WSL2 by periodically checking the status of Nginx. The script helps to prevent WSL2 from shutting down due to inactivity, which can be useful for local development scenarios where you want services like Nginx to remain available without keeping a terminal window open.

A brief documentation (README-keepalive.md) is also included, explaining the concept, usage, and configuration.

This is just a concept/demo and can be moved, modified, or removed as you see fit.
Let me know if you have any suggestions or would like changes!